### PR TITLE
Prevent accidental misuse of Sonar token

### DIFF
--- a/.github/actions/perform-static-analysis/action.yaml
+++ b/.github/actions/perform-static-analysis/action.yaml
@@ -1,8 +1,14 @@
 name: "Perform static analysis"
 description: "Perform static analysis"
 inputs:
+  sonar_organisation_key:
+    description: "Sonar organisation key, used to identify the project"
+    required: false
+  sonar_project_key:
+    description: "Sonar project key, used to identify the project"
+    required: false
   sonar_token:
-    description: "Sonar token API key"
+    description: "Sonar token, the API key"
     required: false
 runs:
   using: "composite"
@@ -16,5 +22,7 @@ runs:
       if: steps.check.outputs.secret_exist == 'true'
       run: |
         export BRANCH_NAME=${GITHUB_HEAD_REF:-$(echo $GITHUB_REF | sed 's#refs/heads/##')}
+        export SONAR_ORGANISATION_KEY=${{ inputs.sonar_organisation_key }}
+        export SONAR_PROJECT_KEY=${{ inputs.sonar_project_key }}
         export SONAR_TOKEN=${{ inputs.sonar_token }}
         ./scripts/reports/perform-static-analysis.sh

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -86,4 +86,6 @@ jobs:
       - name: "Perform static analysis"
         uses: ./.github/actions/perform-static-analysis
         with:
+          sonar_organisation_key: "${{ secrets.SONAR_ORGANISATION_KEY }}"
+          sonar_project_key: "${{ secrets.SONAR_PROJECT_KEY }}"
           sonar_token: "${{ secrets.SONAR_TOKEN }}"

--- a/docs/user-guides/Perform_static_analysis.md
+++ b/docs/user-guides/Perform_static_analysis.md
@@ -24,10 +24,11 @@ Static code analysis is an essential part of modern software development. It pro
 - Create your [SonarCloud](https://sonarcloud.io) project
 - Navigate to project `Administration > Analysis Method > Manually` and select `Other (for JS, TS, Go, Python, PHP, ...)`
 - In the [sonar-scanner.properties](../../scripts/config/sonar-scanner.properties) file, set the following properties according to the information provided above
-  - `sonar.organization`
-  - `sonar.projectKey`
   - `sonar.[language].[coverage-tool].reportPaths` to ensure the unit test coverage is reported back to Sonar
-- Follow the documentation on [creating encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to add the `SONAR_TOKEN` secret to your repository. The GitHub action is already configured to fetch that secret and pass it as a variable
+  - Do not set the `sonar.organization` and `sonar.projectKey` properties in this file; do the next step instead
+- Follow the documentation on [creating encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to add the `SONAR_TOKEN` secret to your repository. The GitHub action is already configured to fetch that secret and pass it as a variable. In addition to that:
+  - Add `SONAR_ORGANISATION_KEY` secret
+  - Add `SONAR_PROJECT_KEY` secret
 - Navigate to project `Administration > Analysis Method` and turn off the `Automatic Analysis` option
 - Please, refrain from adding your repository to the GitHub SonarCloud App. Doing so will duplicate reports and initiate them outside the primary pipeline workflow
 - Confirm that the GitHub action is part of your GitHub CI/CD workflow and enforces the "Sonar Way" quality gates. You can find more information about this in the [NHSE Software Engineering Quality Framework](https://github.com/NHSDigital/software-engineering-quality-framework/blob/main/tools/sonarqube.md)
@@ -37,6 +38,6 @@ Static code analysis is an essential part of modern software development. It pro
 You can run and test static analysis locally on a developer's workstation using the following command
 
 ```shell
-export SONAR_TOKEN=1234567890abcdef1234567890abcdef12345678
+export SONAR_TOKEN=[replace-with-your-sonar-token]
 ./scripts/perform-static-analysis.sh
 ```

--- a/scripts/config/sonar-scanner.properties
+++ b/scripts/config/sonar-scanner.properties
@@ -1,6 +1,6 @@
+# Please, DO NOT set the following properties `sonar.organization` and `sonar.projectKey` in this file. They must be stored as `SONAR_ORGANISATION_KEY` and `SONAR_PROJECT_KEY` GitHub secrets.
+
 sonar.host.url=https://sonarcloud.io
-sonar.organization=nhs-england-tools
-sonar.projectKey=repository-template
 sonar.qualitygate.wait=true
 sonar.sourceEncoding=UTF-8
 sonar.sources=.

--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -35,6 +35,8 @@ function create-report() {
     sonarsource/sonar-scanner-cli:$image_version \
       -Dproject.settings=/usr/src/scripts/config/sonar-scanner.properties \
       -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
+      -Dsonar.organization="$(echo $SONAR_ORGANISATION_KEY)" \
+      -Dsonar.projectKey="$(echo $SONAR_PROJECT_KEY)" \
       -Dsonar.token="$(echo $SONAR_TOKEN)"
 }
 


### PR DESCRIPTION
## Description

Prevent accidental misuse of Sonar token by forcing to store organisation key and project key as GitHub secrets.

- Fixes #101 

## Context

Sonar token is a user token.

## Type of changes

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
