### PR TITLE
Add working `poetry` and `yarn` versions to `.tool-versions`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 nodejs 18.17.1 # Always check AWS and Azure runtime support
 python 3.11.4 # Always check AWS and Azure runtime support
+poetry 1.6.1
 terraform 1.5.6
 pre-commit 3.3.3
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,7 @@
 nodejs 18.17.1 # Always check AWS and Azure runtime support
 python 3.11.4 # Always check AWS and Azure runtime support
 poetry 1.6.1
+yarn 1.22.19
 terraform 1.5.6
 pre-commit 3.3.3
 


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This stops `asdf` from throwing an *incredibly* obnoxious error the first time you try to run the `poetry` binary it's literally just installed for you:

```
 $ poetry --help
No version is set for command poetry
Consider adding one of the following versions in your config file at /Users/alex/src/repository-template/.tool-versions
poetry 1.6.1
```

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
