### PR TITLE
Fix the path to unit.sh in unit.sh

### DIFF
--- a/scripts/tests/unit.sh
+++ b/scripts/tests/unit.sh
@@ -17,4 +17,4 @@ cd "$(git rev-parse --show-toplevel)"
 # tests from here. If you want to run other test suites, see the predefined
 # tasks in scripts/test.mk.
 
-echo "Unit tests are not yet implemented. See scripts/test/unit.sh for more."
+echo "Unit tests are not yet implemented. See scripts/tests/unit.sh for more."


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Missed a character off the path.

## Context

The self-documentation needs to be correct, particularly in the case of self-documentation that the user is going to run into early.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
