### PR TITLE
Change how check-file-format.sh checks changed files

### DIFF
--- a/.github/actions/check-file-format/action.yaml
+++ b/.github/actions/check-file-format/action.yaml
@@ -7,4 +7,4 @@ runs:
       shell: bash
       run: |
         export BRANCH_NAME=origin/${{ github.event.repository.default_branch }}
-        ./scripts/githooks/check-file-format.sh
+        check=branch ./scripts/githooks/check-file-format.sh

--- a/scripts/config/pre-commit.yaml
+++ b/scripts/config/pre-commit.yaml
@@ -10,7 +10,7 @@ repos:
   hooks:
   - id: check-file-format
     name: Check File Format
-    entry: ./scripts/githooks/check-file-format.sh
+    entry: check=staged-changes./scripts/githooks/check-file-format.sh
     language: script
     pass_filenames: false
 - repo: local

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -11,7 +11,6 @@ set +e
 #
 # Options:
 #   BRANCH_NAME=other-branch-than-main  # Branch to compare with, default is `origin/main`
-#   ALL_FILES=true                      # Check all files, default is `false`
 #   VERBOSE=true                        # Show all the executed commands, default is `false`
 #
 # Exit codes:

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -48,18 +48,11 @@ function main() {
   else
 
     # Check changed files only
-    files=$( (git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}; git diff --name-only) | sort | uniq )
-    if [ -n "$files" ]; then
-      while read file; do
-        docker run --rm --platform linux/amd64 \
-          --volume=$PWD:/check \
-          mstruebing/editorconfig-checker:$image_version \
-            ec \
-              --exclude '.git/' \
-              "$file"
-        [ $? != 0 ] && exit_code=1 ||:
-      done < <(echo "$files")
-    fi
+    docker run --rm --platform linux/amd64 \
+      --volume=$PWD:/check \
+      mstruebing/editorconfig-checker:$image_version \
+        sh -c 'ec --exclude ".git/" $(git diff --diff-filter=ACMRT --name-only)'
+    [ $? != 0 ] && exit_code=1 ||:
 
   fi
 }

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -7,7 +7,7 @@ set +e
 # according to the style defined in the `.editorconfig` file.
 #
 # Usage:
-#   $ ./check-file-format.sh
+#   $ check={all,staged-changes,working-tree-changes,branch} [dry_run=true] ./check-file-format.sh
 #
 # Options:
 #   BRANCH_NAME=other-branch-than-main  # Branch to compare with, default is `origin/main`
@@ -18,11 +18,23 @@ set +e
 #   0 - All files are formatted correctly
 #   1 - Files are not formatted correctly
 #
+#
+# The `check` parameter controls which files are checked, so you can
+# limit the scope of the check according to what is appropriate at the
+# point the check is being applied.
+#
+#   check=all: check all files in the repository
+#   check=staged-changes: check only files staged for commit.
+#   check=working-tree-changes: check modified, unstaged files. This is the default.
+#   check=branch: check for all changes since branching from $BRANCH_NAME
+#
+# If the `dry_run` parameter is set to a truthy value, the list of
+# files that ec would check is output, with no check done.
+#
 # Notes:
-#   1) Please, make sure to enable EditorConfig linting in your IDE. For the
+#   Please, make sure to enable EditorConfig linting in your IDE. For the
 #   Visual Studio Code editor it is `editorconfig.editorconfig` that is already
 #   specified in the `./.vscode/extensions.json` file.
-#   2) Due to the file name escaping issue files are checked one by one.
 
 # ==============================================================================
 
@@ -31,27 +43,18 @@ image_version=2.7.1@sha256:dd3ca9ea50ef4518efe9be018d669ef9cf937f6bb5cfe2ef84ff2
 
 # ==============================================================================
 
+
 function main() {
 
   cd $(git rev-parse --show-toplevel)
 
-  if is-arg-true "$ALL_FILES"; then
-
-    # Check all files
-    docker run --rm --platform linux/amd64 \
-      --volume $PWD:/check \
-      mstruebing/editorconfig-checker:$image_version \
-        ec \
-          --exclude '.git/'
-
-  else
-
-    # Check changed files only
-    docker run --rm --platform linux/amd64 \
-      --volume=$PWD:/check \
-      mstruebing/editorconfig-checker:$image_version \
-        sh -c 'ec --exclude ".git/" $(git diff --diff-filter=ACMRT --name-only)'
-  fi
+  # We use /dev/null here as a backstop in case there are no files in the state
+  # we choose.  If the filter comes back empty, adding `/dev/null` onto it has
+  # the effect of preventing `ec` from treating "no files" as "all the files".
+  docker run --rm --platform linux/amd64 \
+    --volume=$PWD:/check \
+    mstruebing/editorconfig-checker:$image_version \
+      sh -c "ec --exclude '.git/' $dry_run_opt \$($filter) /dev/null"
 }
 
 function is-arg-true() {
@@ -65,7 +68,31 @@ function is-arg-true() {
 
 # ==============================================================================
 
+check=${check:-working-tree-changes}
+
+case $check in
+    "all")
+        filter="git ls-files"
+        ;;
+    "staged-changes")
+        filter="git diff --diff-filter=ACMRT --name-only --cached"
+        ;;
+    "working-tree-changes")
+        filter="git diff --diff-filter=ACMRT --name-only"
+        ;;
+    "branch")
+        filter="git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}"
+        ;;
+    *)
+        echo "Unrecognised check mode: $check" >&2 && exit 1
+        ;;
+esac
+
+echo $check
+echo $filter
+
 is-arg-true "$VERBOSE" && set -x
+is-arg-true "$dry_run" && dry_run_opt="--dry-run"
 
 main $*
 

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -27,8 +27,7 @@ set +e
 # ==============================================================================
 
 # SEE: https://hub.docker.com/r/mstruebing/editorconfig-checker/tags, use the `linux/amd64` os/arch
-image_version=2.7.0@sha256:0f8f8dd4f393d29755bef2aef4391d37c34e358d676e9d66ce195359a9c72ef3
-exit_code=0
+image_version=2.7.1@sha256:dd3ca9ea50ef4518efe9be018d669ef9cf937f6bb5cfe2ef84ff2a620b5ddc24
 
 # ==============================================================================
 
@@ -72,4 +71,4 @@ is-arg-true "$VERBOSE" && set -x
 
 main $*
 
-exit $exit_code
+exit 0

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -87,9 +87,6 @@ case $check in
         ;;
 esac
 
-echo $check
-echo $filter
-
 is-arg-true "$VERBOSE" && set -x
 is-arg-true "$dry_run" && dry_run_opt="--dry-run"
 

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -47,6 +47,28 @@ function main() {
 
   cd $(git rev-parse --show-toplevel)
 
+  is-arg-true "$dry_run" && dry_run_opt="--dry-run"
+
+  check=${check:-working-tree-changes}
+  case $check in
+    "all")
+      filter="git ls-files"
+      ;;
+    "staged-changes")
+      filter="git diff --diff-filter=ACMRT --name-only --cached"
+      ;;
+    "working-tree-changes")
+      filter="git diff --diff-filter=ACMRT --name-only"
+      ;;
+    "branch")
+      filter="git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}"
+      ;;
+    *)
+      echo "Unrecognised check mode: $check" >&2 && exit 1
+      ;;
+  esac
+
+
   # We use /dev/null here as a backstop in case there are no files in the state
   # we choose.  If the filter comes back empty, adding `/dev/null` onto it has
   # the effect of preventing `ec` from treating "no files" as "all the files".
@@ -67,28 +89,8 @@ function is-arg-true() {
 
 # ==============================================================================
 
-check=${check:-working-tree-changes}
-
-case $check in
-    "all")
-        filter="git ls-files"
-        ;;
-    "staged-changes")
-        filter="git diff --diff-filter=ACMRT --name-only --cached"
-        ;;
-    "working-tree-changes")
-        filter="git diff --diff-filter=ACMRT --name-only"
-        ;;
-    "branch")
-        filter="git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}"
-        ;;
-    *)
-        echo "Unrecognised check mode: $check" >&2 && exit 1
-        ;;
-esac
 
 is-arg-true "$VERBOSE" && set -x
-is-arg-true "$dry_run" && dry_run_opt="--dry-run"
 
 main $*
 

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -51,8 +51,6 @@ function main() {
       --volume=$PWD:/check \
       mstruebing/editorconfig-checker:$image_version \
         sh -c 'ec --exclude ".git/" $(git diff --diff-filter=ACMRT --name-only)'
-    [ $? != 0 ] && exit_code=1 ||:
-
   fi
 }
 


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Prior to this patch, the `git diff` command used to identify which files to check for editorconfig compliance caught too many files, and did the expensive part of the check inside the per-file loop.

By lucky chance, the editorconfig-checker container image has a `git` binary installed, so we can move the entire loop inside a single container invocation.

Fixes #129.

## Context

It makes the editorconfig check, which is called in a pre-commit hook, fast.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

