### PR TITLE
Check markdown in files known to git, not all files

### DIFF
--- a/scripts/githooks/check-markdown-format.sh
+++ b/scripts/githooks/check-markdown-format.sh
@@ -38,7 +38,7 @@ function main() {
   check=${check:-working-tree-changes}
   case $check in
     "all")
-      files="$(find ./ -type f -name "*.md")"
+      files="$(git ls-files "*.md")"
       ;;
     "staged-changes")
       files="$(git diff --diff-filter=ACMRT --name-only --cached "*.md")"


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

As currently written, `check=all scripts/githooks/check-markdown-format` will not only check files intentionally checked in, it will also check anything under, for instance, `.venv/` or `node_modules/` which are out of our control.

This change makes it only pay attention to checked-in files.  I don't think it was intentional that we lint markdown in dependencies.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
