### PR TITLE
bugfix: pre-commit scripts use env vars but pre-commit.yaml is passing args

### DIFF
--- a/scripts/config/pre-commit.yaml
+++ b/scripts/config/pre-commit.yaml
@@ -3,38 +3,34 @@ repos:
   hooks:
   - id: scan-secrets
     name: Scan secrets
-    entry: ./scripts/githooks/scan-secrets.sh
-    args: ["check=staged-changes"]
-    language: script
+    entry: bash -c 'check=staged-changes ./scripts/githooks/scan-secrets.sh'
+    language: system
     pass_filenames: false
 - repo: local
   hooks:
   - id: check-file-format
     name: Check file format
-    entry: ./scripts/githooks/check-file-format.sh
-    args: ["check=staged-changes"]
-    language: script
+    entry: bash -c 'check=staged-changes ./scripts/githooks/check-file-format.sh'
+    language: system
     pass_filenames: false
 - repo: local
   hooks:
   - id: check-markdown-format
     name: Check Markdown format
-    entry: ./scripts/githooks/check-markdown-format.sh
-    args: ["check=staged-changes"]
-    language: script
+    entry: bash -c 'check=staged-changes ./scripts/githooks/check-markdown-format.sh'
+    language: system
     pass_filenames: false
 - repo: local
   hooks:
   - id: check-english-usage
     name: Check English usage
-    entry: ./scripts/githooks/check-english-usage.sh
-    args: ["check=staged-changes"]
-    language: script
+    entry: bash -c 'check=staged-changes ./scripts/githooks/check-english-usage.sh'
+    language: system
     pass_filenames: false
 - repo: local
   hooks:
   - id: lint-terraform
     name: Lint Terraform
-    entry: ./scripts/githooks/check-terraform-format.sh
-    language: script
+    entry: bash -c './scripts/githooks/check-terraform-format.sh'
+    language: system
     pass_filenames: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixed a bug in the pre-commit configuration where hook scripts were not receiving the required check parameter. Updated all four Git hooks (scan-secrets, check-file-format, check-markdown-format, and check-english-usage) to use environment variables instead of command-line arguments.

Changed from language: script with `args: ["check=staged-changes"]` to `language: system` with inline bash commands using the pattern `bash -c 'check=staged-changes ./scripts/githooks/<script>.sh'`.

(An alternative fix would have been to update the scripts to accept args but this would be a greater change across multiple files and more disruptive to downstream branches when they update.)

## Context

When pushing to git I noticed that the markdown lint action on github was acting differently to the local pre-commit hook. The pre-commit hooks were failing to execute properly because the args parameter was not being correctly passed to the scripts when using `language: script`. This meant the hooks were unable to determine what files to check, breaking the pre-commit functionality. Switching to environment variables with inline bash commands resolves this issue and ensures the hooks correctly check staged changes.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
