### PR TITLE
ci: restrict push trigger to main and add synchronize to PR trigger - ENG-1023

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -5,7 +5,7 @@ name: "CI/CD pull request"
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated the `on:` triggers in the CI/CD pull request workflow:
- Narrowed the `push` trigger from all branches (`"**"`) to `main` only
- Added `synchronize` to the `pull_request` event types, so the workflow also runs when new commits are pushed to an open PR

## Context

Previously the workflow ran on every push to any branch, which caused duplicate runs alongside pull request triggers. Restricting the push trigger to `main` avoids redundant executions. Adding `synchronize` ensures the workflow re-runs whenever a PR is updated with new commits, keeping CI feedback current throughout the review lifecycle.

## Type of changes

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
