### PR TITLE
fix: replace secrets: inherit with explicit secret mappings in CI/CD workflows

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -78,7 +78,11 @@ jobs:
       python_version: "${{ needs.metadata.outputs.python_version }}"
       terraform_version: "${{ needs.metadata.outputs.terraform_version }}"
       version: "${{ needs.metadata.outputs.version }}"
-    secrets: inherit
+    secrets:
+      IDP_AWS_REPORT_UPLOAD_ACCOUNT_ID: ${{ secrets.IDP_AWS_REPORT_UPLOAD_ACCOUNT_ID }}
+      IDP_AWS_REPORT_UPLOAD_REGION: ${{ secrets.IDP_AWS_REPORT_UPLOAD_REGION }}
+      IDP_AWS_REPORT_UPLOAD_ROLE_NAME: ${{ secrets.IDP_AWS_REPORT_UPLOAD_ROLE_NAME }}
+      IDP_AWS_REPORT_UPLOAD_BUCKET_ENDPOINT: ${{ secrets.IDP_AWS_REPORT_UPLOAD_BUCKET_ENDPOINT }}
   test-stage: # Recommended maximum execution time is 5 minutes
     name: "Test stage"
     needs: [metadata, commit-stage]
@@ -91,7 +95,8 @@ jobs:
       python_version: "${{ needs.metadata.outputs.python_version }}"
       terraform_version: "${{ needs.metadata.outputs.terraform_version }}"
       version: "${{ needs.metadata.outputs.version }}"
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   build-stage: # Recommended maximum execution time is 3 minutes
     name: "Build stage"
     needs: [metadata, test-stage]
@@ -105,7 +110,6 @@ jobs:
       python_version: "${{ needs.metadata.outputs.python_version }}"
       terraform_version: "${{ needs.metadata.outputs.terraform_version }}"
       version: "${{ needs.metadata.outputs.version }}"
-    secrets: inherit
   acceptance-stage: # Recommended maximum execution time is 10 minutes
     name: "Acceptance stage"
     needs: [metadata, build-stage]
@@ -119,4 +123,3 @@ jobs:
       python_version: "${{ needs.metadata.outputs.python_version }}"
       terraform_version: "${{ needs.metadata.outputs.terraform_version }}"
       version: "${{ needs.metadata.outputs.version }}"
-    secrets: inherit

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -31,6 +31,19 @@ on:
         description: "Version of the software, set by the CI/CD pipeline workflow"
         required: true
         type: string
+    secrets:
+      IDP_AWS_REPORT_UPLOAD_ACCOUNT_ID:
+        description: "AWS account ID for IDP report upload"
+        required: false
+      IDP_AWS_REPORT_UPLOAD_REGION:
+        description: "AWS region for IDP report upload"
+        required: false
+      IDP_AWS_REPORT_UPLOAD_ROLE_NAME:
+        description: "AWS IAM role name for IDP report upload"
+        required: false
+      IDP_AWS_REPORT_UPLOAD_BUCKET_ENDPOINT:
+        description: "AWS S3 bucket endpoint for IDP report upload"
+        required: false
 
 jobs:
   scan-secrets:

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -31,6 +31,10 @@ on:
         description: "Version of the software, set by the CI/CD pipeline workflow"
         required: true
         type: string
+    secrets:
+      SONAR_TOKEN:
+        description: "SonarCloud token for static analysis"
+        required: true
 
 jobs:
   test-unit:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Replace `secrets: inherit` with explicit secret mappings in the CI/CD pull request workflow and add corresponding `secrets:` declarations to the reusable stage workflows.

- `cicd-1-pull-request.yaml`: `commit-stage` now passes only the four `IDP_AWS_REPORT_UPLOAD_*` secrets; `test-stage` now passes only `SONAR_TOKEN`; `build-stage` and `acceptance-stage` no longer pass any secrets as none are required
- `stage-1-commit.yaml`: added `secrets:` block to `on.workflow_call` declaring the four `IDP_AWS_REPORT_UPLOAD_*` secrets
- `stage-2-test.yaml`: added `secrets:` block to `on.workflow_call` declaring `SONAR_TOKEN`

## Context

SonarCloud flagged the use of `secrets: inherit` in `.github/workflows/cicd-1-pull-request.yaml` (lines 81, 94, 108, and 122) as a security risk.

When `secrets: inherit` is used to call a reusable workflow, all repository secrets are made available to that workflow, violating the principle of least privilege. By replacing it with explicit secret mappings, each reusable workflow receives only the specific secrets it requires, reducing the blast radius of any potential secret exposure.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
