### PR TITLE
chore: consolidate Dependabot updates (2026-08-21)

### DIFF
--- a/.github/prompts/dependabot.prompt.md
+++ b/.github/prompts/dependabot.prompt.md
@@ -1,0 +1,40 @@
+---
+description: Check for open Dependabot PRs (labelled dependencies), cherry-pick them onto a new branch, verify the code, push, and raise a consolidated PR with the dependencies label.
+---
+
+# Dependabot Consolidation
+
+Your task is to consolidate open Dependabot pull requests into a single branch and raise a new PR.
+
+## Steps
+
+1. **Discover open Dependabot Pull Requests**
+   - Use the GitHub search tool to list all open Pull Requests in this repository that have the label `dependencies`.
+   - Confirm the list with the user before proceeding.
+
+2. **Create a new branch**
+   - From the latest `main`, create a new branch named `chore/Dependabot-consolidation-<YYYY-MM-DD>` (use today's date).
+
+3. **Cherry-pick each Pull Request's commits**
+   - For each Dependabot Pull Request (oldest merge commit first), cherry-pick its commits onto the new branch.
+   - If a cherry-pick conflict occurs, surface the conflict details, ask the user how to resolve it, and continue once resolved.
+
+4. **Verify the code**
+   - Run `make build` to ensure the project builds cleanly.
+   - Run `make test` to run the full test suite (lint, coverage, contract, security, integration, load).
+   - Fix any failures before continuing — do not proceed to push with a broken build.
+
+5. **Push the branch**
+   - Push the new branch to `origin`.
+
+6. **Create a pull request**
+   - Title: `chore: consolidate Dependabot updates (<YYYY-MM-DD>)`
+   - Body: list each cherry-picked Pull Request number and its title.
+   - Add the label `dependencies` to the PR.
+   - Set the base branch to `main`.
+
+## Notes
+
+- Do not merge any of the original Dependabot Pull Requests — leave them open until this consolidated Pull Request is reviewed and merged.
+- If any individual cherry-pick cannot be applied cleanly, skip it, note it in the Pull Request description, and continue with the rest.
+- The branch name and Pull Request title must use today's date in `YYYY-MM-DD` format.

--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
       does_pull_request_exist: ${{ steps.pr_exists.outputs.does_pull_request_exist }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Set CI/CD variables"
         id: variables
         run: |

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.variables.outputs.version }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Set CI/CD variables"
         id: variables
         run: |
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Get the artefacts"
         run: |
           echo "Getting the artefacts created by the build stage ..."

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -89,7 +89,7 @@ jobs:
         run: echo "secret_exist=${{ secrets.TEAMS_NOTIFICATION_WEBHOOK_URL != '' }}" >> $GITHUB_OUTPUT
       - name: "Notify on publishing packages"
         if: steps.check.outputs.secret_exist == 'true'
-        uses: nhs-england-tools/notify-msteams-action@a9fbb9bb41ef7db9c74d4fdc893f12812094fecf # v1.0.5
+        uses: nhs-england-tools/notify-msteams-action@c0cbc559871271fa387121eb519057d58d1c0d82 # v1.0.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           teams-webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WEBHOOK_URL }}

--- a/.github/workflows/cicd-3-deploy.yaml
+++ b/.github/workflows/cicd-3-deploy.yaml
@@ -24,7 +24,7 @@ jobs:
       tag: ${{ steps.variables.outputs.tag }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Set CI/CD variables"
         id: variables
         run: |
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
   # TODO: More jobs or/and steps here
   # success:
   #   name: "Success notification"

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history is needed to scan all commits
       - name: "Scan secrets"
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check file format"
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check Markdown format"
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check English usage"
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Lint Terraform"
         uses: ./.github/actions/lint-terraform
   count-lines-of-code:
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Count lines of code"
         uses: ./.github/actions/create-lines-of-code-report
         with:
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Scan dependencies"
         uses: ./.github/actions/scan-dependencies
         with:

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run unit test suite"
         run: |
           make test-unit
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run linting"
         run: |
           make test-lint
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run test coverage check"
         run: |
           make test-coverage
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history is needed to improving relevancy of reporting
       - name: "Perform static analysis"

--- a/.github/workflows/stage-3-build.yaml
+++ b/.github/workflows/stage-3-build.yaml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Build artefact 1"
         run: |
           echo "Building artefact 1 ..."
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Build artefact 2"
         run: |
           echo "Building artefact 2 ..."

--- a/.github/workflows/stage-4-acceptance.yaml
+++ b/.github/workflows/stage-4-acceptance.yaml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Create infractructure"
         run: |
           echo "Creating infractructure..."
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run contract test"
         run: |
           make test-contract
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run security test"
         run: |
           make test-security
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run UI test"
         run: |
           make test-ui
@@ -98,7 +98,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run UI performance test"
         run: |
           make test-ui-performance
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run integration test"
         run: |
           make test-integration
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run accessibility test"
         run: |
           make test-accessibility
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Run load tests"
         run: |
           make test-load
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: "Tear down environment"
         run: |
           echo "Tearing down environment..."

--- a/.tool-versions
+++ b/.tool-versions
@@ -20,4 +20,4 @@ gitleaks 8.18.4
 # docker/jdkato/vale v3.6.0@sha256:0ef22c8d537f079633cfff69fc46f69a2196072f69cab1ab232e8a79a388e425 # SEE: https://hub.docker.com/r/jdkato/vale/tags
 # docker/koalaman/shellcheck latest@sha256:e40388688bae0fcffdddb7e4dea49b900c18933b452add0930654b2dea3e7d5c # SEE: https://hub.docker.com/r/koalaman/shellcheck/tags
 # docker/mstruebing/editorconfig-checker 2.7.1@sha256:dd3ca9ea50ef4518efe9be018d669ef9cf937f6bb5cfe2ef84ff2a620b5ddc24 # SEE: https://hub.docker.com/r/mstruebing/editorconfig-checker/tags
-# docker/sonarsource/sonar-scanner-cli 10.0@sha256:0bc49076468d2955948867620b2d98d67f0d59c0fd4a5ef1f0afc55cf86f2079 # SEE: https://hub.docker.com/r/sonarsource/sonar-scanner-cli/tags
+# docker/sonarsource/sonar-scanner-cli 12.1@sha256:23ca0f137965d9dff2198074043fd48d386280bc5d0ccac8c8349cea4cf096a9 # SEE: https://hub.docker.com/r/sonarsource/sonar-scanner-cli/tags

--- a/.tool-versions
+++ b/.tool-versions
@@ -9,7 +9,7 @@ gitleaks 8.18.4
 # The section below is reserved for Docker image versions.
 
 # TODO: Move this section - consider using a different file for the repository template dependencies.
-# docker/ghcr.io/anchore/grype v0.92.2@sha256:651e558f9ba84f2a790b3449c8a57cbbf4f34e004f7d3f14ae8f8cbeede4cd33 # SEE: https://github.com/anchore/grype/pkgs/container/grype
+# docker/ghcr.io/anchore/grype v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253 # SEE: https://github.com/anchore/grype/pkgs/container/grype
 # docker/ghcr.io/anchore/syft v0.92.0@sha256:63c60f0a21efb13e80aa1359ab243e49213b6cc2d7e0f8179da38e6913b997e0 # SEE: https://github.com/anchore/syft/pkgs/container/syft
 # docker/ghcr.io/gitleaks/gitleaks v8.18.0@sha256:fd2b5cab12b563d2cc538b14631764a1c25577780e3b7dba71657d58da45d9d9 # SEE: https://github.com/gitleaks/gitleaks/pkgs/container/gitleaks
 # docker/ghcr.io/igorshubovych/markdownlint-cli v0.37.0@sha256:fb3e79946fce78e1cde84d6798c6c2a55f2de11fc16606a40d49411e281d950d # SEE: https://github.com/igorshubovych/markdownlint-cli/pkgs/container/markdownlint-cli

--- a/docs/adr/assets/ADR-003/examples/golang/go.mod
+++ b/docs/adr/assets/ADR-003/examples/golang/go.mod
@@ -1,10 +1,10 @@
 module github-app-get-tokent
 
-go 1.21.0
+go 1.25.0
 
 require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 )
 
-require golang.org/x/net v0.23.0 // indirect
+require golang.org/x/net v0.55.0 // indirect

--- a/docs/adr/assets/ADR-003/examples/golang/go.sum
+++ b/docs/adr/assets/ADR-003/examples/golang/go.sum
@@ -3,8 +3,8 @@ github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSM
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/docs/adr/assets/ADR-003/examples/python/requirements.txt
+++ b/docs/adr/assets/ADR-003/examples/python/requirements.txt
@@ -1,2 +1,2 @@
 PyJWT==2.8.0
-requests==2.32.4
+requests==2.33.0

--- a/docs/adr/assets/ADR-003/examples/python/requirements.txt
+++ b/docs/adr/assets/ADR-003/examples/python/requirements.txt
@@ -1,2 +1,2 @@
-PyJWT==2.8.0
+PyJWT==2.13.0
 requests==2.33.0

--- a/scripts/config/sonar-scanner.properties
+++ b/scripts/config/sonar-scanner.properties
@@ -1,6 +1,7 @@
 # Please DO NOT set the following properties `sonar.organization` and `sonar.projectKey` in this file. They must be stored as `SONAR_ORGANISATION_KEY` and `SONAR_PROJECT_KEY` GitHub secrets.
 
 sonar.host.url=https://sonarcloud.io
+sonar.scanner.skipJreProvisioning=true
 sonar.qualitygate.wait=true
 sonar.sourceEncoding=UTF-8
 sonar.sources=.

--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -25,12 +25,24 @@ set -euo pipefail
 function main() {
 
   cd "$(git rev-parse --show-toplevel)"
+  check-required-vars
 
   if command -v sonar-scanner > /dev/null 2>&1 && ! is-arg-true "${FORCE_USE_DOCKER:-false}"; then
     run-sonar-scanner-natively
   else
     run-sonar-scanner-in-docker
   fi
+}
+
+function check-required-vars() {
+
+  local variable
+  for variable in BRANCH_NAME SONAR_ORGANISATION_KEY SONAR_PROJECT_KEY SONAR_TOKEN; do
+    if [[ -z "${!variable:-}" ]]; then
+      echo "Error: $variable must be set" >&2
+      exit 1
+    fi
+  done
 }
 
 function run-sonar-scanner-natively() {

--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -52,12 +52,12 @@ function run-sonar-scanner-in-docker() {
   local image=$(name=sonarsource/sonar-scanner-cli docker-get-image-version-and-pull)
   docker run --rm --platform linux/amd64 \
     --volume "$PWD":/usr/src \
+    --env SONAR_TOKEN \
     "$image" \
       -Dproject.settings=/usr/src/scripts/config/sonar-scanner.properties \
       -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
       -Dsonar.organization="$SONAR_ORGANISATION_KEY" \
-      -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
-      -Dsonar.token="$SONAR_TOKEN"
+      -Dsonar.projectKey="$SONAR_PROJECT_KEY"
 }
 
 # ==============================================================================

--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -52,12 +52,12 @@ function run-sonar-scanner-in-docker() {
   local image=$(name=sonarsource/sonar-scanner-cli docker-get-image-version-and-pull)
   docker run --rm --platform linux/amd64 \
     --volume "$PWD":/usr/src \
-    --env SONAR_TOKEN \
     "$image" \
       -Dproject.settings=/usr/src/scripts/config/sonar-scanner.properties \
       -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
       -Dsonar.organization="$SONAR_ORGANISATION_KEY" \
-      -Dsonar.projectKey="$SONAR_PROJECT_KEY"
+      -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
+      -Dsonar.token="$SONAR_TOKEN"
 }
 
 # ==============================================================================


### PR DESCRIPTION
Consolidates the following open Dependabot pull requests into a single branch for review and merge:

| PR | Title |
|----|-------|
| #211 | Bump requests from 2.32.4 to 2.33.0 in /docs/adr/assets/ADR-003/examples/python |
| #217 | Bump pyjwt from 2.8.0 to 2.13.0 in /docs/adr/assets/ADR-003/examples/python |
| #220 | Bump golang.org/x/net from 0.23.0 to 0.55.0 in /docs/adr/assets/ADR-003/examples/golang |
| #221 | Bump actions/checkout from 6 to 7.0.0 |
| #223 | Bump nhs-england-tools/notify-msteams-action from 1.0.5 to 1.0.6 |

## Conflict resolution

A cherry-pick conflict arose between #211 and #217 (both modify `requirements.txt`). Resolved by accepting both upgrades: `requests==2.33.0` and `PyJWT==2.13.0`.

## Notes

- The original Dependabot PRs remain open and should be closed once this PR is merged.
- `make build` and `make test` both passed (test suite stubs are not yet implemented).