### PR TITLE
docs(adr): require weighted scoring and tech radar alignment

### DIFF
--- a/docs/adr/ADR-nnn_Any_Decision_Record_Template.md
+++ b/docs/adr/ADR-nnn_Any_Decision_Record_Template.md
@@ -31,6 +31,8 @@ Describe the context and the problem statement. Is there a relationship to other
 
 Note that environmental limitations or restrictions (for example accepted technology standards, commonly recognised patterns, engineering and architecture principles, organisational policies, and governance) may narrow the options. This must be explicitly documented. This is a point-in-time decision, recorded so it can be understood, justified, and revisited when needed.
 
+Note that any technology choice, including languages, frameworks, libraries, and tooling, must align with the Tech_Radar.md file, where that file exists and is a local copy of the NHS Tech Radar. The NHS Tech Radar defines the default tools for each language stack. Any deviation requires explicit justification within this ADR and approval by the Engineering Board.
+
 ## Decision ✅
 
 ### Assumptions 🧩
@@ -43,45 +45,60 @@ List the decision drivers that motivate this decision or course of action. This 
 
 ### Options 🔀
 
-Consider a comprehensive set of alternative options. Include weighting or scoring if it improves clarity.
+Consider a comprehensive set of alternative options. Always use weighted scoring. Identify the top one or two criteria for this decision context and weight them higher than the rest. State the weighting method once and apply it consistently across all options.
 
 #### Option A: {Descriptive name} (Selected) ✅
 
+**Top criteria**: {Criterion 1, Criterion 2}
+
+**Weighted option score**: {0.0 to 5.0} (define the formula; use weights)
+
 Summarise the core idea behind the selected option, including how it works at a high level and any critical constraints or prerequisites.
 
-| Criteria (example) | Score/Notes                                   |
-| ------------------ | --------------------------------------------- |
-| Criterion 1        | ⭐⭐⭐ {reasoning for score}                  |
-| Criterion 2        | ⭐⭐ {reasoning for score}                    |
-| Criterion 3        | ⭐⭐⭐ {reasoning for score}                  |
-| Criterion 4        | ⭐⭐ {reasoning for score}                    |
-| Effort             | {T-shirt size or estimate with justification} |
+| Criteria (example) | Weight | Score/Notes                                   |
+| ------------------ | ------ | --------------------------------------------- |
+| Criterion 1        | {1-5}  | ⭐⭐⭐ {reasoning for score}                  |
+| Criterion 2        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Criterion 3        | {1-5}  | ⭐⭐⭐ {reasoning for score}                  |
+| Criterion 4        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Effort             | {1-5}  | {T-shirt size or estimate with justification} |
+| Total score        |        | {0.0 to 5.0}                                  |
 
 #### Option B: {Descriptive name}
 
+**Top criteria**: {Criterion 1, Criterion 2}
+
+**Weighted option score**: {0.0 to 5.0} (define the formula; use weights)
+
 Describe the second viable option, including the mechanisms involved and notable strengths/weaknesses.
 
-| Criteria (example) | Score/Notes                                   |
-| ------------------ | --------------------------------------------- |
-| Criterion 1        | ⭐⭐ {reasoning for score}                    |
-| Criterion 2        | ⭐⭐ {reasoning for score}                    |
-| Criterion 3        | ⭐ {reasoning for score}                      |
-| Criterion 4        | ⭐⭐⭐ {reasoning for score}                  |
-| Effort             | {T-shirt size or estimate with justification} |
+| Criteria (example) | Weight | Score/Notes                                   |
+| ------------------ | ------ | --------------------------------------------- |
+| Criterion 1        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Criterion 2        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Criterion 3        | {1-5}  | ⭐ {reasoning for score}                      |
+| Criterion 4        | {1-5}  | ⭐⭐⭐ {reasoning for score}                  |
+| Effort             | {1-5}  | {T-shirt size or estimate with justification} |
+| Total score        |        | {0.0 to 5.0}                                  |
 
 **Why not chosen**: Capture the concrete reasons this option was rejected. Reference measurable risks, constraints, or trade-offs evidenced in the codebase or architecture.
 
 #### Option C: {Descriptive name}
 
+**Top criteria**: {Criterion 1, Criterion 2}
+
+**Weighted option score**: {0.0 to 5.0} (define the formula; use weights)
+
 Describe the third option (or more if needed) with enough detail for readers to evaluate it at a glance.
 
-| Criteria (example) | Score/Notes                                   |
-| ------------------ | --------------------------------------------- |
-| Criterion 1        | ⭐⭐ {reasoning for score}                    |
-| Criterion 2        | ⭐ {reasoning for score}                      |
-| Criterion 3        | ⭐ {reasoning for score}                      |
-| Criterion 4        | ⭐⭐ {reasoning for score}                    |
-| Effort             | {T-shirt size or estimate with justification} |
+| Criteria (example) | Weight | Score/Notes                                   |
+| ------------------ | ------ | --------------------------------------------- |
+| Criterion 1        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Criterion 2        | {1-5}  | ⭐ {reasoning for score}                      |
+| Criterion 3        | {1-5}  | ⭐ {reasoning for score}                      |
+| Criterion 4        | {1-5}  | ⭐⭐ {reasoning for score}                    |
+| Effort             | {1-5}  | {T-shirt size or estimate with justification} |
+| Total score        |        | {0.0 to 5.0}                                  |
 
 **Why not chosen**: Explain the specific drawbacks, blockers, or context conflicts that ruled out this option.
 


### PR DESCRIPTION
# docs(adr): require weighted scoring and tech radar alignment

## Description

This PR tightens the ADR decision-record template so option comparisons are consistent and auditable, and so technology choices are checked against the NHS Tech Radar before an ADR is approved. It is a documentation-only change to the template that future ADR authors will follow; no existing ADR content is retrofitted.

- [docs/adr/ADR-nnn_Any_Decision_Record_Template.md](docs/adr/ADR-nnn_Any_Decision_Record_Template.md#L31-L34): adds a new paragraph to `## Context` requiring any technology choice to align with `Tech_Radar.md` where that file exists, with deviations needing explicit justification and Engineering Board approval.
- [docs/adr/ADR-nnn_Any_Decision_Record_Template.md](docs/adr/ADR-nnn_Any_Decision_Record_Template.md#L48-L49): rewrites the `### Options` instruction from "include weighting or scoring if it improves clarity" (optional) to "always use weighted scoring", including choosing top criteria and stating the weighting method once for consistency.
- [docs/adr/ADR-nnn_Any_Decision_Record_Template.md](docs/adr/ADR-nnn_Any_Decision_Record_Template.md#L53-L56): adds `**Top criteria**` and `**Weighted option score**` lines under each option heading (A, B, C).
- [docs/adr/ADR-nnn_Any_Decision_Record_Template.md](docs/adr/ADR-nnn_Any_Decision_Record_Template.md#L61-L70): adds a `Weight` column and a `Total score` row to each option's scoring table, replacing the star-only scoring convention with a numeric weighted model.

## Context

The driver is that the previous template made scoring optional and used unweighted stars, which let ADRs skip rigorous comparison or weight all criteria equally regardless of decision context, and had no explicit requirement to check new technology choices against the NHS Tech Radar. This PR makes both checks mandatory: weighted scoring for every option, and Tech Radar alignment (with an Engineering Board approval escape hatch for deviations) for every technology choice. There is no linked GitHub issue or ADR for this change; it is scoped entirely to the template file.

## How to test it

This is a documentation-only change to a Markdown template with no executable behaviour.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the contributing guidelines
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] I have described how to test these changes in the section above
- [ ] This PR is a result of pair or mob programming
- [x] This PR is a result of AI-assisted development sessions

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.